### PR TITLE
fix(ios): reader chapter-crossing flicker + touch double-skip; simulator/runtime policy

### DIFF
--- a/.claude/agents/ios-companion.md
+++ b/.claude/agents/ios-companion.md
@@ -32,12 +32,51 @@ You consume the same `/api/jobs`, `/api/uploads`, `/api/sessions`, `/api/telemet
 5. **Match existing terminology** from `i18n/translations.ts` (en + pt-BR) — don't invent new labels for the same concept.
 6. **Build via mise + xcodebuild** — never assume the user has Xcode IDE open. CI may build via `release-desktop.yml` analog.
 
+## SIMULATOR / RUNTIME POLICY — NON-NEGOTIABLE (this Mac: Intel 2018, 8 GiB)
+
+This machine is disk- and thermally-constrained and kernel-panics under load.
+The following are **absolute** rules. When in doubt, **preserve disk space**.
+
+- **NEVER install, add, download, or recreate iOS simulators or OS runtimes** without
+  the user's **explicit** authorization. Forbidden even "just in case", "to test",
+  "to unblock the build", or "because Xcode asked".
+- **NEVER download large iOS/watchOS/tvOS/visionOS runtimes** on your own.
+  **NEVER install watchOS/tvOS/visionOS at all.**
+- **Treating "download platform/component/runtime" as a fix is forbidden by default.**
+- **Physical iPhone first.** If a real device is connected, ALWAYS prefer it and avoid
+  Simulator/CoreSimulator. If the user asks to run on the real iPhone, do **not** fall
+  back to Simulator automatically.
+- Keep **zero (preferred)** or the absolute minimum simulators. If ever authorized:
+  exactly **1 iOS runtime + 1 small compatible device**.
+
+### When `xcodebuild` says a platform/runtime is missing — DO NOT DOWNLOAD. In order:
+1. Clean stale simulators/devices (`xcrun simctl delete unavailable` / `all`).
+2. Use the connected real device.
+3. Find a Simulator-free workaround.
+4. Report the blocker to the user — stop, don't download.
+
+### Mandatory iOS flow on this Mac
+1. Check connected physical devices: `xcrun xcdevice list`.
+2. Remove unneeded CoreSimulator devices: `xcrun simctl delete unavailable` (or `all`).
+3. Generate project with `xcodegen` if needed.
+4. Build for the real iPhone:
+   `xcodebuild ... -destination 'platform=iOS,id=<UDID_DO_IPHONE>'`.
+5. Install + launch on device:
+   `xcrun devicectl device install app ...` / `xcrun devicectl device process launch ...`.
+6. **Only with explicit user authorization**, consider Simulator.
+
+Prefer GitHub Actions / Release Desktop for iOS artifacts and simulator validation.
+See `feedback_ios_no_extra_simulators` and `feedback_mac_caterr_panic` memories +
+CLAUDE.md "Local iOS Simulator Safety".
+
 ## Workflow
 
 1. Survey what already exists at `ios/` (scaffold if absent).
 2. Read the relevant TypeScript service to understand the API shape exactly.
 3. Build a minimal vertical slice (e.g., job list → SSE progress → chapter playback) before adding polish.
-4. Use the smallest Xcode-compatible iPhone simulator/device profile on the smallest compatible iOS runtime. Ask `xcode-toolchain-manager` to verify runtimes first when destinations fail; do not default to latest/large simulators.
+4. Target the **connected physical iPhone** per the Simulator policy above. Never
+   default to latest/large simulators; never download a runtime to satisfy a
+   destination — clean, use device, workaround, or report instead.
 
 ## Output format
 

--- a/.claude/agents/ios-companion.md
+++ b/.claude/agents/ios-companion.md
@@ -56,7 +56,7 @@ The following are **absolute** rules. When in doubt, **preserve disk space**.
 4. Report the blocker to the user — stop, don't download.
 
 ### Mandatory iOS flow on this Mac
-1. Check connected physical devices: `xcrun xcdevice list`.
+1. Check connected physical devices: `xcrun xcdevice list` / `xcrun devicectl list devices`.
 2. Remove unneeded CoreSimulator devices: `xcrun simctl delete unavailable` (or `all`).
 3. Generate project with `xcodegen` if needed.
 4. Build for the real iPhone:
@@ -64,6 +64,22 @@ The following are **absolute** rules. When in doubt, **preserve disk space**.
 5. Install + launch on device:
    `xcrun devicectl device install app ...` / `xcrun devicectl device process launch ...`.
 6. **Only with explicit user authorization**, consider Simulator.
+
+### Hard fact: local device build needs exactly 1 iOS runtime (verified 2026-06-26)
+On Xcode 26.3 the iPhone shows `iOS 26.x is not installed` until the iOS platform
+component exists. The ONLY CLI way to get it is `xcodebuild -downloadPlatform iOS`,
+which ALWAYS bundles a Simulator runtime (~9.7 GiB) + ~33 simulator devices — there is
+no device-support-only download. So the floor is **1 iOS runtime**, not zero.
+- DO NOT use `-downloadPlatform iOS -buildVersion <X>` (errors "not available") or
+  `-downloadAllPlatforms` (pulls tvOS/watchOS/visionOS — forbidden).
+- After the download, shrink to the minimum:
+  1. `xcrun simctl delete all` (drop all auto-created sim devices; we use the real iPhone).
+  2. `xcrun simctl runtime delete <UDID>` on every OTHER runtime so exactly 1 remains
+     (keep the newest, matching the device major).
+- `CoreSimulator.framework` in `/Library/Developer/PrivateFrameworks/` must be present
+  or `xcodebuild` aborts at plugin load even for device builds.
+- Verified working: 1 runtime (iOS 26.3.1), 0 sim devices, app signed "Apple
+  Development", installed + launched on iPhone 16e via `devicectl`.
 
 Prefer GitHub Actions / Release Desktop for iOS artifacts and simulator validation.
 See `feedback_ios_no_extra_simulators` and `feedback_mac_caterr_panic` memories +

--- a/ios/EpubToMp3/EpubToMp3/Views/ReaderView.swift
+++ b/ios/EpubToMp3/EpubToMp3/Views/ReaderView.swift
@@ -381,7 +381,17 @@ struct ReaderView: View {
         // or any UI outside this view.
         .modifier(ReaderColorSchemeModifier(theme: settings.readerTheme))
         .compatOnChange(of: chapter.id) { _ in
-            currentPage = 0
+            // Landing page for the new chapter. On a forward crossing we land
+            // on page 0; on a BACKWARD crossing (retreat) we must land on the
+            // previous chapter's LAST page. Seed `currentPage` accordingly
+            // BEFORE the new pages arrive so `TextKitPageView`'s token-change
+            // re-seed (animated:false) presents the correct page directly. The
+            // old code zeroed to 0 and then a polling task snapped to the last
+            // page afterwards — that second hop re-navigated animated, which is
+            // the wrong-page flash the user saw when crossing to the previous
+            // chapter. `Int.max` clamps to the last page the instant pages land.
+            let wantsLastPage = jumpToLastPageForChapterId == "__pending__"
+            currentPage = wantsLastPage ? Int.max : 0
             isPageTurning = false
             renderedAttributed = nil
             paginationCache.pages = []
@@ -394,9 +404,12 @@ struct ReaderView: View {
             // frame (theme background) is correct here; the new chapter's
             // pages replace it within a frame or two.
             paginationCache.lastValidPages = []
-            // If retreatPage requested last-page landing, poll until the new
-            // chapter's pages are ready then snap to the last one.
-            if jumpToLastPageForChapterId == "__pending__" {
+            // Retreat: refine the `Int.max` sentinel down to the real last
+            // index once pagination stabilises, so the binding holds a sane
+            // value for everything downstream (page-number footer, persisted
+            // position). No animated hop occurs — the seed already showed the
+            // last page; this only normalises the stored index.
+            if wantsLastPage {
                 jumpToLastPageForChapterId = nil
                 jumpToLastPageTask?.cancel()
                 jumpToLastPageTask = Task { @MainActor in
@@ -411,7 +424,7 @@ struct ReaderView: View {
                         if Task.isCancelled { return }
                         let p = paginationCache.pages
                         if !p.isEmpty && p.count == prevCount {
-                            currentPage = p.count - 1
+                            if currentPage != p.count - 1 { currentPage = p.count - 1 }
                             return
                         }
                         prevCount = p.count

--- a/ios/EpubToMp3/EpubToMp3/Views/TextKitPageView.swift
+++ b/ios/EpubToMp3/EpubToMp3/Views/TextKitPageView.swift
@@ -312,6 +312,15 @@ struct TextKitPageView: UIViewControllerRepresentable {
 
         func navigate(_ direction: UIPageViewController.NavigationDirection,
                       in pvc: UIPageViewController) {
+            // A chapter crossing is in flight: the host has bumped the chapter
+            // but the new `pages` haven't landed / been re-seeded yet, so the
+            // displayed controller still carries the OLD chapter's
+            // `pageIndex`. Acting on it now would (a) re-fire
+            // onAdvance/onPrevious off the stale last/first page — skipping a
+            // whole chapter on the second tap — or (b) navigate within the old
+            // index space that's about to be torn down. Ignore the turn until
+            // the swap settles (the token-change re-seed clears the latch).
+            guard !isAwaitingChapterSwap else { return }
             guard !isTransitioning,
                   let current = pvc.viewControllers?.first as? TextKitPageController
             else { return }

--- a/ios/EpubToMp3/EpubToMp3UITests/RepeatedCrossingUITests.swift
+++ b/ios/EpubToMp3/EpubToMp3UITests/RepeatedCrossingUITests.swift
@@ -1,0 +1,181 @@
+import XCTest
+
+/// Regression for "chapter crossing stops working after the first time".
+/// Crosses several chapter boundaries in a row by SWIPE (then by TAP), and by
+/// going forward then backward, asserting each crossing actually changes the
+/// chapter index. Catches a stuck swap latch / disabled gesture after the
+/// first cross.
+final class RepeatedCrossingUITests: XCTestCase {
+    override func setUpWithError() throws { continueAfterFailure = false }
+
+    private func chapter(_ app: XCUIApplication) -> (index: Int, total: Int)? {
+        let label = app.staticTexts["flicker.probe.chapter"].firstMatch.label
+        let parts = label.split(separator: "/").map(String.init)
+        guard parts.count == 2, let i = Int(parts[0]), let t = Int(parts[1]) else { return nil }
+        return (i, t)
+    }
+    private func indicator(_ app: XCUIApplication) -> (page: Int, total: Int)? {
+        let label = app.staticTexts["reader.pageIndicator"].firstMatch.label
+        let parts = label.split(separator: " ").map(String.init)
+        guard parts.count >= 3, let p = Int(parts[0]), let t = Int(parts[2]) else { return nil }
+        return (p, t)
+    }
+    private func flickerTotal(_ app: XCUIApplication) -> Int {
+        // Summary is "stale=N spurious=N empty=N".
+        let label = app.staticTexts[flickerSummaryAXId].firstMatch.label
+        return label.split(separator: " ").reduce(0) { acc, kv in
+            acc + (Int(kv.split(separator: "=").last.map(String.init) ?? "") ?? 0)
+        }
+    }
+    private let flickerSummaryAXId = "flicker.probe.summary"
+
+    private func open() throws -> XCUIApplication {
+        XCUIDevice.shared.orientation = .portrait
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-uiTestResetReaderPosition", "-uiTestFlickerProbe",
+            "-uiTestReaderLayout", "paginated",
+        ]
+        app.launch()
+        let firstBook = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH %@", "library.bookTile.")
+        ).firstMatch
+        guard firstBook.waitForExistence(timeout: 20) else { throw XCTSkip("No book.") }
+        firstBook.tap()
+        guard app.staticTexts["reader.pageIndicator"].firstMatch.waitForExistence(timeout: 20) else {
+            throw XCTSkip("No page indicator.")
+        }
+        return app
+    }
+
+    /// Cross forward by SWIPE three times in a row; the chapter index must
+    /// increment each time (no stuck latch after the first).
+    func testRepeatedForwardSwipeCrossings() throws {
+        let app = try open()
+        let right = app.coordinate(withNormalizedOffset: CGVector(dx: 0.85, dy: 0.5))
+        let from = app.coordinate(withNormalizedOffset: CGVector(dx: 0.8, dy: 0.5))
+        let to = app.coordinate(withNormalizedOffset: CGVector(dx: 0.2, dy: 0.5))
+
+        for cross in 0..<3 {
+            guard let ch = chapter(app), ch.index + 1 < ch.total else {
+                throw XCTSkip("Ran out of chapters at crossing \(cross).")
+            }
+            let startIndex = ch.index
+            // Page to the last page of the current chapter.
+            var g = 0
+            while let cur = indicator(app), cur.page < cur.total, g < 60 {
+                right.tap(); usleep(600_000); g += 1
+            }
+            // Swipe forward off the last page.
+            from.press(forDuration: 0.05, thenDragTo: to)
+            usleep(1_600_000)
+            let now = chapter(app)?.index
+            XCTAssertEqual(now, startIndex + 1,
+                           "crossing #\(cross): swipe must advance chapter \(startIndex)->\(startIndex + 1), got \(String(describing: now))")
+        }
+    }
+
+    /// THE likely user scenario: reading immersively (chrome HIDDEN), tap
+    /// forward off the last page must cross to the next chapter. With chrome
+    /// hidden the PVC's own pan is no longer shadowed by the chrome overlay
+    /// and can race the tap.
+    func testForwardTapCrossingWithChromeHidden() throws {
+        let app = try open()
+        let right = app.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.5))
+        guard let start = chapter(app), start.index + 1 < start.total else {
+            throw XCTSkip("No room to cross forward.")
+        }
+        // Hide chrome.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+        usleep(800_000)
+
+        // Page to the last page (taps still turn pages with chrome hidden).
+        var g = 0
+        while let cur = indicator(app), cur.page < cur.total, g < 60 { right.tap(); usleep(600_000); g += 1 }
+        // One more forward tap on the last page → must cross chapter.
+        right.tap(); usleep(1_500_000)
+        XCTAssertEqual(chapter(app)?.index, start.index + 1,
+                       "forward tap on the last page with chrome HIDDEN must cross to the next chapter, " +
+                       "got \(String(describing: chapter(app)))")
+    }
+
+    /// Cross forward by TAP, then immediately back by TAP — both directions
+    /// must work in the same session (no latch left armed by the forward one).
+    func testForwardThenBackwardCrossingByTap() throws {
+        let app = try open()
+        let right = app.coordinate(withNormalizedOffset: CGVector(dx: 0.85, dy: 0.5))
+        let left = app.coordinate(withNormalizedOffset: CGVector(dx: 0.15, dy: 0.5))
+
+        guard let start = chapter(app), start.index + 1 < start.total else {
+            throw XCTSkip("No room to cross forward.")
+        }
+        // Forward: page to last, tap once more.
+        var g = 0
+        while let cur = indicator(app), cur.page < cur.total, g < 60 { right.tap(); usleep(600_000); g += 1 }
+        right.tap(); usleep(1_500_000)
+        XCTAssertEqual(chapter(app)?.index, start.index + 1, "forward tap must advance chapter")
+
+        // Backward: from page 1, tap left once.
+        left.tap(); usleep(2_500_000)
+        XCTAssertEqual(chapter(app)?.index, start.index,
+                       "backward tap from page 1 must return to the previous chapter")
+    }
+
+    /// A second forward tap fired DURING the chapter swap (before the new
+    /// pages land) must NOT skip a whole chapter. Before the fix, `navigate`
+    /// read the OLD chapter's last-page index while the swap was still in
+    /// flight and re-fired `onAdvanceChapter`, jumping two chapters on a
+    /// quick double tap. The swap-latch guard in `navigate` must swallow it.
+    func testDoubleTapAtBoundaryAdvancesExactlyOneChapter() throws {
+        let app = try open()
+        let right = app.coordinate(withNormalizedOffset: CGVector(dx: 0.85, dy: 0.5))
+        guard let start = chapter(app), start.index + 2 < start.total else {
+            throw XCTSkip("Need at least two chapters ahead.")
+        }
+        // Page to the last page of the current chapter.
+        var g = 0
+        while let cur = indicator(app), cur.page < cur.total, g < 60 { right.tap(); usleep(600_000); g += 1 }
+        // Two rapid forward taps with no settle between them: the first
+        // crosses; the second lands inside the swap window.
+        right.tap()
+        usleep(120_000)
+        right.tap()
+        usleep(2_000_000)
+        XCTAssertEqual(chapter(app)?.index, start.index + 1,
+                       "a rapid double tap at the boundary must advance exactly ONE chapter, " +
+                       "got \(String(describing: chapter(app)))")
+    }
+
+    /// Crossing BACKWARD must settle on the previous chapter's LAST page in a
+    /// single hop — no flash of page 1 first, and no recorded flicker events.
+    /// Before the fix the reader seeded page 0 then a polling task animated to
+    /// the last page (a visible second hop / re-navigation flicker).
+    func testBackwardCrossingLandsOnLastPageWithoutFlicker() throws {
+        let app = try open()
+        let right = app.coordinate(withNormalizedOffset: CGVector(dx: 0.85, dy: 0.5))
+        let left = app.coordinate(withNormalizedOffset: CGVector(dx: 0.15, dy: 0.5))
+        guard let start = chapter(app), start.index + 1 < start.total else {
+            throw XCTSkip("No room to cross forward first.")
+        }
+        // Cross forward once so there is a previous chapter to return to.
+        var g = 0
+        while let cur = indicator(app), cur.page < cur.total, g < 60 { right.tap(); usleep(600_000); g += 1 }
+        right.tap(); usleep(1_500_000)
+        guard chapter(app)?.index == start.index + 1 else { throw XCTSkip("Forward cross failed.") }
+
+        // Zero the probe right before the backward crossing we care about.
+        app.buttons["flicker.probe.reset"].firstMatch.tap()
+        usleep(200_000)
+
+        // Backward off page 1 → previous chapter, must land on ITS last page.
+        left.tap(); usleep(2_500_000)
+        XCTAssertEqual(chapter(app)?.index, start.index,
+                       "backward tap must return to the previous chapter")
+        if let ind = indicator(app) {
+            XCTAssertEqual(ind.page, ind.total,
+                           "backward crossing must land on the previous chapter's LAST page, got \(ind)")
+        }
+        XCTAssertEqual(flickerTotal(app), 0,
+                       "backward crossing must record zero flicker events")
+    }
+}


### PR DESCRIPTION
## Summary
Hardens the local iOS simulator/runtime policy and fixes the two residual reader bugs at chapter boundaries (the only place flicker / touch errors still occurred).

### Reader fixes (commit 3fe953e)
1. **Touch double-skip**: `TextKitPageView.navigate()` ignored the swap latch. A tap fired in the window after the chapter changed but before the new pages were re-seeded read the OLD chapter's `pageIndex` and re-fired `onAdvance/onPrevious` — a quick double tap at the boundary skipped a whole chapter. Now guarded on `isAwaitingChapterSwap`, like the edge-pan and `updateUIViewController` paths.
2. **Backward-crossing flash**: `ReaderView` zeroed `currentPage` then a polling task animated to the previous chapter's last page (a visible second hop). Now seeds `currentPage = Int.max` so the token-change re-seed (`animated:false`) lands on the last page directly; the polling task only normalises the stored index.

### Policy (commits fc24d2a, 238397d)
Hardens the ios-companion simulator/runtime guard; documents that a local iPhone build needs exactly one iOS runtime.

## Tests
`RepeatedCrossingUITests` gains `testDoubleTapAtBoundaryAdvancesExactlyOneChapter` and `testBackwardCrossingLandsOnLastPageWithoutFlicker`.

Verified on a physical iPhone 16e — **5 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)